### PR TITLE
Conditional imports to support operating with `pydantic>2` installed

### DIFF
--- a/prefect_hightouch/api_client/models/cron_schedule.py
+++ b/prefect_hightouch/api_client/models/cron_schedule.py
@@ -1,6 +1,11 @@
 from typing import Any, Dict, List, Type, TypeVar
 
-from pydantic import BaseModel, Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Field
+else:
+    from pydantic import BaseModel, Field
 
 from ..types import UNSET
 

--- a/prefect_hightouch/api_client/models/dbt_schedule.py
+++ b/prefect_hightouch/api_client/models/dbt_schedule.py
@@ -1,6 +1,11 @@
 from typing import Any, Dict, List, Type, TypeVar
 
-from pydantic import BaseModel, Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Field
+else:
+    from pydantic import BaseModel, Field
 
 from ..models.dbt_schedule_account import DBTScheduleAccount
 from ..models.dbt_schedule_job import DBTScheduleJob

--- a/prefect_hightouch/api_client/models/dbt_schedule_account.py
+++ b/prefect_hightouch/api_client/models/dbt_schedule_account.py
@@ -1,6 +1,11 @@
 from typing import Any, Dict, List, Type, TypeVar
 
-from pydantic import BaseModel, Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Field
+else:
+    from pydantic import BaseModel, Field
 
 from ..types import UNSET
 

--- a/prefect_hightouch/api_client/models/dbt_schedule_job.py
+++ b/prefect_hightouch/api_client/models/dbt_schedule_job.py
@@ -1,6 +1,11 @@
 from typing import Any, Dict, List, Type, TypeVar
 
-from pydantic import BaseModel, Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Field
+else:
+    from pydantic import BaseModel, Field
 
 from ..types import UNSET
 

--- a/prefect_hightouch/api_client/models/destination.py
+++ b/prefect_hightouch/api_client/models/destination.py
@@ -2,7 +2,12 @@ import datetime
 from typing import Any, Dict, List, Type, TypeVar, cast
 
 from dateutil.parser import isoparse
-from pydantic import BaseModel, Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Field
+else:
+    from pydantic import BaseModel, Field
 
 from ..models.destination_configuration import DestinationConfiguration
 from ..types import UNSET

--- a/prefect_hightouch/api_client/models/destination_configuration.py
+++ b/prefect_hightouch/api_client/models/destination_configuration.py
@@ -1,6 +1,11 @@
 from typing import Any, Dict, List, Type, TypeVar
 
-from pydantic import BaseModel, Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Field
+else:
+    from pydantic import BaseModel, Field
 
 from ..types import UNSET
 

--- a/prefect_hightouch/api_client/models/interval.py
+++ b/prefect_hightouch/api_client/models/interval.py
@@ -1,6 +1,11 @@
 from typing import Any, Dict, List, Type, TypeVar
 
-from pydantic import BaseModel, Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Field
+else:
+    from pydantic import BaseModel, Field
 
 from ..models.interval_unit import IntervalUnit
 from ..types import UNSET

--- a/prefect_hightouch/api_client/models/interval_schedule.py
+++ b/prefect_hightouch/api_client/models/interval_schedule.py
@@ -1,6 +1,11 @@
 from typing import Any, Dict, List, Type, TypeVar
 
-from pydantic import BaseModel, Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Field
+else:
+    from pydantic import BaseModel, Field
 
 from ..models.interval import Interval
 from ..types import UNSET

--- a/prefect_hightouch/api_client/models/list_destination_response_200.py
+++ b/prefect_hightouch/api_client/models/list_destination_response_200.py
@@ -1,6 +1,11 @@
 from typing import Any, Dict, List, Type, TypeVar
 
-from pydantic import BaseModel, Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Field
+else:
+    from pydantic import BaseModel, Field
 
 from ..models.destination import Destination
 from ..types import UNSET

--- a/prefect_hightouch/api_client/models/list_model_response_200.py
+++ b/prefect_hightouch/api_client/models/list_model_response_200.py
@@ -1,6 +1,11 @@
 from typing import Any, Dict, List, Type, TypeVar
 
-from pydantic import BaseModel, Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Field
+else:
+    from pydantic import BaseModel, Field
 
 from ..models.model import Model
 from ..types import UNSET

--- a/prefect_hightouch/api_client/models/list_source_response_200.py
+++ b/prefect_hightouch/api_client/models/list_source_response_200.py
@@ -1,6 +1,11 @@
 from typing import Any, Dict, List, Type, TypeVar
 
-from pydantic import BaseModel, Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Field
+else:
+    from pydantic import BaseModel, Field
 
 from ..models.source import Source
 from ..types import UNSET

--- a/prefect_hightouch/api_client/models/list_sync_response_200.py
+++ b/prefect_hightouch/api_client/models/list_sync_response_200.py
@@ -1,6 +1,11 @@
 from typing import Any, Dict, List, Type, TypeVar
 
-from pydantic import BaseModel, Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Field
+else:
+    from pydantic import BaseModel, Field
 
 from ..models.sync import Sync
 from ..types import UNSET

--- a/prefect_hightouch/api_client/models/list_sync_runs_response_200.py
+++ b/prefect_hightouch/api_client/models/list_sync_runs_response_200.py
@@ -1,6 +1,11 @@
 from typing import Any, Dict, List, Type, TypeVar
 
-from pydantic import BaseModel, Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Field
+else:
+    from pydantic import BaseModel, Field
 
 from ..models.sync_run import SyncRun
 from ..types import UNSET

--- a/prefect_hightouch/api_client/models/model.py
+++ b/prefect_hightouch/api_client/models/model.py
@@ -2,7 +2,12 @@ import datetime
 from typing import Any, Dict, List, Type, TypeVar, Union, cast
 
 from dateutil.parser import isoparse
-from pydantic import BaseModel, Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Field
+else:
+    from pydantic import BaseModel, Field
 
 from ..models.model_custom import ModelCustom
 from ..models.model_dbt import ModelDbt

--- a/prefect_hightouch/api_client/models/model_custom.py
+++ b/prefect_hightouch/api_client/models/model_custom.py
@@ -1,6 +1,11 @@
 from typing import Any, Dict, List, Type, TypeVar
 
-from pydantic import BaseModel, Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Field
+else:
+    from pydantic import BaseModel, Field
 
 from ..types import UNSET
 

--- a/prefect_hightouch/api_client/models/model_dbt.py
+++ b/prefect_hightouch/api_client/models/model_dbt.py
@@ -1,6 +1,11 @@
 from typing import Any, Dict, List, Type, TypeVar
 
-from pydantic import BaseModel, Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Field
+else:
+    from pydantic import BaseModel, Field
 
 from ..types import UNSET
 

--- a/prefect_hightouch/api_client/models/model_raw.py
+++ b/prefect_hightouch/api_client/models/model_raw.py
@@ -1,6 +1,11 @@
 from typing import Any, Dict, List, Type, TypeVar
 
-from pydantic import BaseModel, Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Field
+else:
+    from pydantic import BaseModel, Field
 
 from ..types import UNSET
 

--- a/prefect_hightouch/api_client/models/model_table.py
+++ b/prefect_hightouch/api_client/models/model_table.py
@@ -1,6 +1,11 @@
 from typing import Any, Dict, List, Type, TypeVar
 
-from pydantic import BaseModel, Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Field
+else:
+    from pydantic import BaseModel, Field
 
 from ..types import UNSET
 

--- a/prefect_hightouch/api_client/models/model_tags.py
+++ b/prefect_hightouch/api_client/models/model_tags.py
@@ -1,6 +1,11 @@
 from typing import Any, Dict, List, Type, TypeVar
 
-from pydantic import BaseModel, Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Field
+else:
+    from pydantic import BaseModel, Field
 
 from ..types import UNSET
 

--- a/prefect_hightouch/api_client/models/model_visual.py
+++ b/prefect_hightouch/api_client/models/model_visual.py
@@ -1,6 +1,11 @@
 from typing import Any, Dict, List, Type, TypeVar
 
-from pydantic import BaseModel, Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Field
+else:
+    from pydantic import BaseModel, Field
 
 from ..types import UNSET
 

--- a/prefect_hightouch/api_client/models/record_day_boolean_or_undefined.py
+++ b/prefect_hightouch/api_client/models/record_day_boolean_or_undefined.py
@@ -1,6 +1,11 @@
 from typing import Any, Dict, List, Type, TypeVar, Union
 
-from pydantic import BaseModel, Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Field
+else:
+    from pydantic import BaseModel, Field
 
 from ..types import UNSET, Unset
 

--- a/prefect_hightouch/api_client/models/source.py
+++ b/prefect_hightouch/api_client/models/source.py
@@ -2,7 +2,12 @@ import datetime
 from typing import Any, Dict, List, Type, TypeVar
 
 from dateutil.parser import isoparse
-from pydantic import BaseModel, Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Field
+else:
+    from pydantic import BaseModel, Field
 
 from ..models.source_configuration import SourceConfiguration
 from ..types import UNSET

--- a/prefect_hightouch/api_client/models/source_configuration.py
+++ b/prefect_hightouch/api_client/models/source_configuration.py
@@ -1,6 +1,11 @@
 from typing import Any, Dict, List, Type, TypeVar
 
-from pydantic import BaseModel, Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Field
+else:
+    from pydantic import BaseModel, Field
 
 from ..types import UNSET
 

--- a/prefect_hightouch/api_client/models/sync.py
+++ b/prefect_hightouch/api_client/models/sync.py
@@ -2,7 +2,12 @@ import datetime
 from typing import Any, Dict, List, Type, TypeVar, cast
 
 from dateutil.parser import isoparse
-from pydantic import BaseModel, Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Field
+else:
+    from pydantic import BaseModel, Field
 
 from ..models.sync_configuration import SyncConfiguration
 from ..models.sync_schedule import SyncSchedule

--- a/prefect_hightouch/api_client/models/sync_configuration.py
+++ b/prefect_hightouch/api_client/models/sync_configuration.py
@@ -1,6 +1,11 @@
 from typing import Any, Dict, List, Type, TypeVar
 
-from pydantic import BaseModel, Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Field
+else:
+    from pydantic import BaseModel, Field
 
 from ..types import UNSET
 

--- a/prefect_hightouch/api_client/models/sync_run.py
+++ b/prefect_hightouch/api_client/models/sync_run.py
@@ -2,7 +2,12 @@ import datetime
 from typing import Any, Dict, List, Type, TypeVar, Union
 
 from dateutil.parser import isoparse
-from pydantic import BaseModel, Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Field
+else:
+    from pydantic import BaseModel, Field
 
 from ..models.sync_run_failed_rows import SyncRunFailedRows
 from ..models.sync_run_planned_rows import SyncRunPlannedRows

--- a/prefect_hightouch/api_client/models/sync_run_failed_rows.py
+++ b/prefect_hightouch/api_client/models/sync_run_failed_rows.py
@@ -1,6 +1,11 @@
 from typing import Any, Dict, List, Type, TypeVar
 
-from pydantic import BaseModel, Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Field
+else:
+    from pydantic import BaseModel, Field
 
 from ..types import UNSET
 

--- a/prefect_hightouch/api_client/models/sync_run_planned_rows.py
+++ b/prefect_hightouch/api_client/models/sync_run_planned_rows.py
@@ -1,6 +1,11 @@
 from typing import Any, Dict, List, Type, TypeVar
 
-from pydantic import BaseModel, Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Field
+else:
+    from pydantic import BaseModel, Field
 
 from ..types import UNSET
 

--- a/prefect_hightouch/api_client/models/sync_run_successful_rows.py
+++ b/prefect_hightouch/api_client/models/sync_run_successful_rows.py
@@ -1,6 +1,11 @@
 from typing import Any, Dict, List, Type, TypeVar
 
-from pydantic import BaseModel, Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Field
+else:
+    from pydantic import BaseModel, Field
 
 from ..types import UNSET
 

--- a/prefect_hightouch/api_client/models/sync_schedule.py
+++ b/prefect_hightouch/api_client/models/sync_schedule.py
@@ -1,6 +1,11 @@
 from typing import Any, Dict, List, Type, TypeVar, Union
 
-from pydantic import BaseModel, Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Field
+else:
+    from pydantic import BaseModel, Field
 
 from ..models.cron_schedule import CronSchedule
 from ..models.dbt_schedule import DBTSchedule

--- a/prefect_hightouch/api_client/models/trigger_run_custom_input.py
+++ b/prefect_hightouch/api_client/models/trigger_run_custom_input.py
@@ -1,6 +1,11 @@
 from typing import Any, Dict, List, Type, TypeVar, Union
 
-from pydantic import BaseModel, Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Field
+else:
+    from pydantic import BaseModel, Field
 
 from ..types import UNSET, Unset
 

--- a/prefect_hightouch/api_client/models/trigger_run_input.py
+++ b/prefect_hightouch/api_client/models/trigger_run_input.py
@@ -1,6 +1,11 @@
 from typing import Any, Dict, List, Type, TypeVar, Union
 
-from pydantic import BaseModel, Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Field
+else:
+    from pydantic import BaseModel, Field
 
 from ..types import UNSET, Unset
 

--- a/prefect_hightouch/api_client/models/trigger_run_output.py
+++ b/prefect_hightouch/api_client/models/trigger_run_output.py
@@ -1,6 +1,11 @@
 from typing import Any, Dict, List, Type, TypeVar
 
-from pydantic import BaseModel, Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Field
+else:
+    from pydantic import BaseModel, Field
 
 from ..types import UNSET
 

--- a/prefect_hightouch/api_client/models/validate_error_json.py
+++ b/prefect_hightouch/api_client/models/validate_error_json.py
@@ -1,6 +1,11 @@
 from typing import Any, Dict, List, Type, TypeVar
 
-from pydantic import BaseModel, Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Field
+else:
+    from pydantic import BaseModel, Field
 
 from ..models.validate_error_json_details import ValidateErrorJSONDetails
 from ..models.validate_error_json_message import ValidateErrorJSONMessage

--- a/prefect_hightouch/api_client/models/validate_error_json_details.py
+++ b/prefect_hightouch/api_client/models/validate_error_json_details.py
@@ -1,6 +1,11 @@
 from typing import Any, Dict, List, Type, TypeVar
 
-from pydantic import BaseModel, Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Field
+else:
+    from pydantic import BaseModel, Field
 
 from ..types import UNSET
 

--- a/prefect_hightouch/api_client/models/visual_cron_schedule.py
+++ b/prefect_hightouch/api_client/models/visual_cron_schedule.py
@@ -1,6 +1,11 @@
 from typing import Any, Dict, List, Type, TypeVar
 
-from pydantic import BaseModel, Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Field
+else:
+    from pydantic import BaseModel, Field
 
 from ..models.visual_cron_schedule_expressions_item import (
     VisualCronScheduleExpressionsItem,

--- a/prefect_hightouch/api_client/models/visual_cron_schedule_expressions_item.py
+++ b/prefect_hightouch/api_client/models/visual_cron_schedule_expressions_item.py
@@ -1,6 +1,11 @@
 from typing import Any, Dict, List, Type, TypeVar
 
-from pydantic import BaseModel, Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Field
+else:
+    from pydantic import BaseModel, Field
 
 from ..models.record_day_boolean_or_undefined import RecordDayBooleanOrUndefined
 from ..types import UNSET

--- a/prefect_hightouch/api_client/types.py
+++ b/prefect_hightouch/api_client/types.py
@@ -2,8 +2,14 @@
 from http import HTTPStatus
 from typing import BinaryIO, Generic, MutableMapping, Optional, Tuple, TypeVar
 
-from pydantic import BaseModel
-from pydantic.generics import GenericModel
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel
+    from pydantic.v1.generics import GenericModel
+else:
+    from pydantic import BaseModel
+    from pydantic.generics import GenericModel
 
 
 class Unset(BaseModel):

--- a/prefect_hightouch/credentials/generated.py
+++ b/prefect_hightouch/credentials/generated.py
@@ -14,7 +14,12 @@ to perform authenticated interactions with Hightouch.
 from typing import Any, Dict
 
 from prefect.blocks.core import Block
-from pydantic import Field, SecretStr
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import Field, SecretStr
+else:
+    from pydantic import Field, SecretStr
 
 from prefect_hightouch.api_client.client import AuthenticatedClient
 


### PR DESCRIPTION
Following the compatibility work we've done in `prefect`, we also want to apply the
same compatibility changes to all Prefect-maintained collections.  We're following the
convention that Prefect will always use `pydantic<2` idioms, leaning on the
`pydantic.v1` module of `pydantic>2` to aid us in this.  With these changes, we can
operate normally regardless of the installed version.

Until `prefect` fully deprecates `pydantic` versions below 2.0, we'll continue to
maintain that constraint of using only v1 idioms.

This is part of a series of identical PRs for all of our maintained collections.
